### PR TITLE
Problem with unusable guest additions fixed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@ Vagrant.configure(2) do |config|
   config.ssh.insert_key = false 
   config.vm.define "node1" do |node1|
     node1.vm.box = "geerlingguy/centos7"
+	node1.vm.box_version = "1.1.7"
     node1.vm.network "private_network", ip: "192.168.199.2"
     node1.vm.hostname = "node1.example.com"
     node1.vm.provision "shell", path: "scripts/install_ambari_server.sh"
@@ -14,6 +15,7 @@ Vagrant.configure(2) do |config|
   end
   config.vm.define "node2" do |node2|
     node2.vm.box = "geerlingguy/centos7"
+	node2.vm.box_version = "1.1.7"
     node2.vm.network "private_network", ip: "192.168.199.3"
     node2.vm.hostname = "node2.example.com"
     node2.vm.provision "shell", path: "scripts/install_ambari_agent.sh"
@@ -25,6 +27,7 @@ Vagrant.configure(2) do |config|
   end
   config.vm.define "node3" do |node3|
     node3.vm.box = "geerlingguy/centos7"
+	node3.vm.box_version = "1.1.7"
     node3.vm.network "private_network", ip: "192.168.199.4"
     node3.vm.hostname = "node3.example.com"
     node3.vm.provision "shell", path: "scripts/install_ambari_agent.sh"


### PR DESCRIPTION
Fixes the error of unusable guest additions by adding 1 line of code into Vagrantfile.
The added specifies the version of the used boxes from "geerlingguy/centos7"

More information in https://github.com/wardviaene/hadoop-ops-course/issues/2